### PR TITLE
Connect to chat over HTTPS by default

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -23,6 +23,7 @@ class Client extends EventEmitter {
      * @arg {String} password Client password
      * @arg {Object} [options] Gekkou options (optional)
      * @arg {Boolean} [options.autoreconnect=true] Have Gekkou autoreconnect when connection is lost
+     * @arg {Boolean} [options.forcehttp=false] Disable HTTPS and force connecting to chat over HTTP. Only enable if you have problems connecting over HTTPS.
      * @arg {Number} [options.defaultImageSize=150] The default size to return user avatars or anything else. Can be whatever you want.
      */
     constructor(username, password, options = {}) {
@@ -34,6 +35,7 @@ class Client extends EventEmitter {
 
         this.options = {
             "autoreconnect": true,
+            "forcehttp": false,
             "defaultImageSize": 150
         };
 

--- a/lib/structures/Room.js
+++ b/lib/structures/Room.js
@@ -74,7 +74,7 @@ class Room extends EventEmitter {
     }
 
     initializeSocket() {
-        this.socket = Socket.connect("http://chat.wikia-services.com", {
+        this.socket = Socket.connect(this._client.options.forcehttp === true ? "http://chat.wikia-services.com" : "https://chat.wikia-services.com", {
             query: {
                 name: this._client.username,
                 serverId: this.server,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gekkou",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "It's time to ditch chatbot-rb",
   "main": "./",
   "engines": {


### PR DESCRIPTION
This PR changes the chat server url to use the HTTPS URL (https://chat.wikia-services.com) by default.

The _forcehttp_ config flag allows to disable this setting and force connecting over HTTP.